### PR TITLE
Adds support for pending fulfillments

### DIFF
--- a/resources/views/slots/fulfillments/service-selector.blade.php
+++ b/resources/views/slots/fulfillments/service-selector.blade.php
@@ -161,8 +161,9 @@
                     disableCourierOptions();
                 @endif
 
-                @if($shipment->committed)
-                    toggleTrackingForm(false);
+                toggleTrackingForm(false);
+
+                @if($shipment->committed && $fulfillment->state === 'successful')
                     document.getElementById("tracking-code").disabled = true;
                     document.getElementById("tracking-url").disabled = true;
                 @endif

--- a/src/BulkActions/CompletePendingFulfillments.php
+++ b/src/BulkActions/CompletePendingFulfillments.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Techquity\Aero\Couriers\BulkActions;
+
+use Aero\Admin\ResourceLists\FulfillmentsResourceList;
+use Aero\Fulfillment\Models\Fulfillment;
+use Techquity\Aero\Couriers\Abstracts\AbstractQueueableBulkAction;
+use Techquity\Aero\Couriers\Traits\UsesCourierDriver;
+
+class CompletePendingFulfillments extends AbstractQueueableBulkAction
+{
+    use UsesCourierDriver;
+
+    protected $list;
+
+    public function __construct(FulfillmentsResourceList $list)
+    {
+        $this->list = $list;
+    }
+
+    public function handle(): void
+    {
+        $this->list->items()->each(function (Fulfillment $fulfillment) {
+            if ($fulfillment->state === Fulfillment::PENDING) {
+                $fulfillment->state = Fulfillment::SUCCESSFUL;
+                $fulfillment->save();
+            }
+        });
+    }
+}

--- a/src/CourierDriver.php
+++ b/src/CourierDriver.php
@@ -139,6 +139,14 @@ class CourierDriver extends FulfillmentDriver
     }
 
     /**
+     * Determine what status the fulfilment should be.
+     */
+    public static function determineFulfillmentStatus(): string
+    {
+        return Fulfillment::SUCCESSFUL;
+    }
+
+    /**
      * Make the fulfillment request.
      *
      * @return \Aero\Fulfillment\Contracts\Response

--- a/src/CouriersServiceProvider.php
+++ b/src/CouriersServiceProvider.php
@@ -16,6 +16,7 @@ use Aero\Fulfillment\Models\FulfillmentMethod;
 use Aero\Responses\ResponseBuilder;
 use Techquity\Aero\Couriers\BulkActions\CollectShipmentsBulkAction;
 use Techquity\Aero\Couriers\BulkActions\CommitCourierShipmentsBulkAction;
+use Techquity\Aero\Couriers\BulkActions\CompletePendingFulfillments;
 use Techquity\Aero\Couriers\BulkActions\DeleteCourierConnectorsBulkAction;
 use Techquity\Aero\Couriers\BulkActions\DeleteCourierServicesBulkAction;
 use Techquity\Aero\Couriers\Models\{CourierConnector, CourierService, CourierShipment, PendingLabel};
@@ -78,6 +79,10 @@ class CouriersServiceProvider extends ModuleServiceProvider
         AdminSlot::inject('orders.index.header.buttons', function ($_) {
             return view('couriers::slots.pending-labels');
         });
+
+        BulkAction::create(CompletePendingFulfillments::class, FulfillmentsResourceList::class)
+            ->title('Complete pending fulfillments')
+            ->permissions('fulfillments.view');
 
         $this->configureCourierManagerModule();
 

--- a/src/Http/Responses/Steps/UpdateFulfillmentShipment.php
+++ b/src/Http/Responses/Steps/UpdateFulfillmentShipment.php
@@ -11,13 +11,15 @@ class UpdateFulfillmentShipment implements ResponseStep
     {
         $fulfillment = $builder->fulfillment;
 
-        if (!isset($fulfillment->method) && $fulfillment->method->isCourier || !$fulfillment->courierShipment) {
-            return $next($builder);
+        if (
+            (isset($fulfillment->method) && $fulfillment->method->isCourier || $fulfillment->courierShipment) &&
+            !empty($builder->request->service) &&
+            !empty($builder->request->connector)
+        ) {
+            $fulfillment->courierShipment->courierService()->associate($builder->request->service);
+            $fulfillment->courierShipment->courierConnector()->associate($builder->request->connector);
+            $fulfillment->courierShipment->save();
         }
-
-        $fulfillment->courierShipment->courierService()->associate($builder->request->service);
-        $fulfillment->courierShipment->courierConnector()->associate($builder->request->connector);
-        $fulfillment->courierShipment->save();
 
         return $next($builder);
     }

--- a/src/Http/Responses/Steps/UpdateFulfillmentShipment.php
+++ b/src/Http/Responses/Steps/UpdateFulfillmentShipment.php
@@ -11,11 +11,11 @@ class UpdateFulfillmentShipment implements ResponseStep
     {
         $fulfillment = $builder->fulfillment;
 
-        if (
-            (isset($fulfillment->method) && $fulfillment->method->isCourier || $fulfillment->courierShipment) &&
-            !empty($builder->request->service) &&
-            !empty($builder->request->connector)
-        ) {
+        if (!isset($fulfillment->method) && $fulfillment->method->isCourier || !$fulfillment->courierShipment) {
+            return $next($builder);
+        }
+
+        if (!empty($builder->request->service) && !empty($builder->request->connector)) {
             $fulfillment->courierShipment->courierService()->associate($builder->request->service);
             $fulfillment->courierShipment->courierConnector()->associate($builder->request->connector);
             $fulfillment->courierShipment->save();

--- a/src/Models/CourierShipment.php
+++ b/src/Models/CourierShipment.php
@@ -133,7 +133,7 @@ class CourierShipment extends Model
         $this->fulfillments->each->update([
             'tracking_code' => ($response ? $response->getTrackingNumber() : null) ?? '',
             'tracking_url' => ($response ? $response->getTrackingUrl() : null) ?? '',
-            'state' => Fulfillment::SUCCESSFUL
+            'state' => $this->driver::determineFulfillmentStatus()
         ]);
 
         $this->orders->each(function (Order $order) {


### PR DESCRIPTION
Adds in support for individual courier drivers to determine the status of a fulfillment when committed, this will allow different couriers to use settings to instead set a committed fulfillment as "Pending". This can be useful if the client doesn't want their shipments to auto dispatch when sent to the courier, or for couriers such as Royal Mail who don't send tracking information until the labels are printed.

With this in mind, added support to edit the tracking details of a fulfillment if it's not in a successful state. This allows clients to manually add tracking details if for any reason it hasn't came through from the courier, before the fulfillment is marked as successful and the order is dispatched.

Fixed a bug when saving a fulfillment, the existing code always expected a courier service and connector to be provided but this isn't true (if for example you're only updating tracking) so the courier service and connector is unset from the shipment and this then breaks the fulfillment and you cannot access it in the admin due to an error.