### PR TITLE
Resolve an issue attempting to create a null label

### DIFF
--- a/src/CourierDriver.php
+++ b/src/CourierDriver.php
@@ -212,10 +212,12 @@ class CourierDriver extends FulfillmentDriver
 
                 } else {
                     $shipments->each(function ($shipment) {
-                        (new PendingLabel([
-                            'label' => $shipment->label,
-                            'admin_id' => $this->admin->id
-                        ]))->save();
+                        if ($shipment->label) {
+                            (new PendingLabel([
+                                'label' => $shipment->label,
+                                'admin_id' => $this->admin->id
+                            ]))->save();
+                        }
                     });
                 }
             });


### PR DESCRIPTION
Don't try and create a pending label if we don't have a label, this stops shipments from sending as it throws a fatal integrity constraint error.