### PR TITLE
Add custom fields to fulfillments

### DIFF
--- a/database/migrations/2023_05_09_130741_add_custom_fields_to_fulfillments.php
+++ b/database/migrations/2023_05_09_130741_add_custom_fields_to_fulfillments.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCustomFieldsToFulfillments extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('fulfillments', function (Blueprint $table) {
+            $table->string('custom_fields')->after('delivery_note')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('fulfillments', function (Blueprint $table) {
+            $table->dropColumn('custom_fields');
+        });
+    }
+};


### PR DESCRIPTION
Adds custom fields column to the fulfillments table. This can be used to store a serialised array of custom fields to send to couriers depending on a clients specification.