### PR TITLE
Add option to segment couriers by groups

### DIFF
--- a/database/migrations/2023_05_11_082349_add_group_to_courier_services_table.php
+++ b/database/migrations/2023_05_11_082349_add_group_to_courier_services_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddGroupToCourierServicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('courier_services', function (Blueprint $table) {
+            $table->string('group')->nullable()->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('courier_services', function (Blueprint $table) {
+            $table->dropColumn('group');
+        });
+    }
+};

--- a/resources/views/slots/fulfillments/service-selector.blade.php
+++ b/resources/views/slots/fulfillments/service-selector.blade.php
@@ -10,11 +10,15 @@
                             @if (isset($fulfillment) && !$fulfillment->isOpen()) disabled @endif>
                             <option value="">Manual</option>
                             @foreach ($services as $carrier => $group)
-                                @foreach ($group as $key => $item)
-                                    <option data-courier="{{ $carrier }}" value="{{ $key }}" class="hidden"
-                                        @if ($selectedService === $key) selected @endif>
-                                        {{ $item }}
-                                    </option>
+                                @foreach ($group as $groupKey => $data)
+                                    <optgroup data-courier="{{ $carrier }}" label="{{ $groupKey }}">
+                                        @foreach ($data as $key => $item)
+                                            <option data-courier="{{ $carrier }}" value="{{ $key }}" class="hidden"
+                                                @if ($selectedService === $key) selected @endif>
+                                                {{ $item }}
+                                            </option>
+                                        @endforeach
+                                    </optgroup>
                                 @endforeach
                             @endforeach
                         </select>


### PR DESCRIPTION
Adds the option to segment couriers by groups, which is then used to segment the select dropdown into a more manageable list. Also added the service code to the option name.