### PR TITLE
Fully implement courier service groups

### DIFF
--- a/database/migrations/2023_05_15_104234_create_courier_service_groups_table.php
+++ b/database/migrations/2023_05_15_104234_create_courier_service_groups_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('courier_service_groups', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->integer('sort')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('courier_service_groups');
+    }
+};

--- a/database/migrations/2023_05_15_104253_add_group_id_to_courier_services_table.php
+++ b/database/migrations/2023_05_15_104253_add_group_id_to_courier_services_table.php
@@ -30,6 +30,7 @@ return new class extends Migration
     {
         Schema::table('courier_services', function (Blueprint $table) {
             $table->dropColumn('courier_service_group_id');
+            $table->string('group')->nullable()->after('description');
         });
     }
 };

--- a/database/migrations/2023_05_15_104253_add_group_id_to_courier_services_table.php
+++ b/database/migrations/2023_05_15_104253_add_group_id_to_courier_services_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('courier_services', function (Blueprint $table) {
+            $table->unsignedBigInteger('courier_service_group_id')->nullable()->after('description');
+
+            $table->foreign('courier_service_group_id')
+                ->references('id')
+                ->on('courier_service_groups')
+                ->onDelete('set null');
+
+            $table->dropColumn('group'); // We don't need the string version anymore
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('courier_services', function (Blueprint $table) {
+            $table->dropColumn('courier_service_group_id');
+        });
+    }
+};

--- a/resources/views/resource-lists/refresh-services.blade.php
+++ b/resources/views/resource-lists/refresh-services.blade.php
@@ -16,6 +16,11 @@
                         Deleted Services
                     </a>
                 </li>
+                <li>
+                    <a href="{{ route('admin.courier-manager.service-groups.index') }}" class="block py-2 px-4 font-normal">
+                        Service Groups
+                    </a>
+                </li>
             </ul>
         </template>
     </dropdown-menu>

--- a/resources/views/resource-lists/service-groups.blade.php
+++ b/resources/views/resource-lists/service-groups.blade.php
@@ -1,0 +1,34 @@
+@extends('admin::layouts.list')
+
+    @section('content-above')
+        <form action="{{ isset($group) ? route('admin.courier-manager.service-groups.update', $group) : route('admin.courier-manager.service-groups.store')  }}" method="post">
+            <fieldset class="w-full" @cannot('couriers.manage-services') disabled="disabled" @endcan>
+                <div class="flex card mb-4">
+                    {{ csrf_field() }}
+                    @if($group)
+                        @method('PUT')
+                    @endif
+                    <div class="w-1/5 mr-2">
+                        <label class="block" for="name">Name</label>
+                        <input type="text" id="name" name="name" class="w-full" value="{{ old('name', optional($group)->name) }}">
+                    </div>
+                    <div class="w-1/5 mr-2">
+                        <label class="block" for="sort">Sort</label>
+                        <input type="number" id="sort" name="sort" class="w-full" value="{{ old('sort', optional($group)->sort) }}">
+                    </div>
+                    <div class="w-1/5 flex items-end ml-2">
+                        @can('couriers.manage-services')
+                            <button class="btn btn-secondary w-full text-center block align-bottom" type="submit">
+                                @if($group)
+                                    Update Group
+                                @else
+                                    Add Group
+                                @endif
+                            </button>
+                        @endcan
+                    </div>
+                </div>
+            </fieldset>
+        </form>
+    @endsection
+

--- a/resources/views/resource-lists/services.blade.php
+++ b/resources/views/resource-lists/services.blade.php
@@ -11,8 +11,16 @@
                         <input type="text" id="name" name="name" class="w-full" value="{{ old('name', $service->name) }}">
                     </div>
                     <div class="w-1/5 ml-2">
-                        <label class="block" for="group">Group</label>
-                        <input type="text" id="group" name="group" class="w-full" value="{{ old('group', $service->group) }}">
+                        <label class="block" for="courier_service_group_id">Group</label>
+                        <select name="courier_service_group_id" id="courier_service_group_id" class="w-full" style="margin-top: 0.5rem">
+                            <option value=""></option>
+                            @foreach(\Techquity\Aero\Couriers\Models\CourierServiceGroup::all() as $group)
+                                <option value="{{ $group->id }}"
+                                        {{ $group->id === $service->courier_service_group_id ? 'selected' : '' }}>
+                                    {{ $group->name }}
+                                </option>
+                            @endforeach
+                        </select>
                     </div>
                     <div class="w-1/5 flex items-end ml-2">
                         @can('couriers.manage-services')

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Techquity\Aero\Couriers\Http\Controllers\CourierConnectorsController;
+use Techquity\Aero\Couriers\Http\Controllers\CourierServiceGroupsController;
 use Techquity\Aero\Couriers\Http\Controllers\CourierServicesController;
 use Techquity\Aero\Couriers\Http\Controllers\CourierShipmentsController;
 use Techquity\Aero\Couriers\Http\Controllers\CourierCollectionsController;
@@ -31,6 +32,13 @@ Route::prefix('/courier/services')->middleware('can:couriers.manage-services')->
     Route::get('/{service}', [CourierServicesController::class, 'index'])->name('edit');
     Route::put('/{service}', [CourierServicesController::class, 'update'])->name('update');
     Route::post('/refresh', [CourierServicesController::class, 'store'])->name('store')->middleware('throttle:60,1');
+});
+
+Route::prefix('/courier/service-groups')->middleware('can:couriers.manage-services')->name('admin.courier-manager.service-groups.')->group(function () {
+    Route::get('/', [CourierServiceGroupsController::class, 'index'])->name('index');
+    Route::post('/', [CourierServiceGroupsController::class, 'store'])->name('store');
+    Route::get('/{group}', [CourierServiceGroupsController::class, 'index'])->name('edit');
+    Route::put('/{group}', [CourierServiceGroupsController::class, 'update'])->name('update');
 });
 
 Route::prefix('/courier/collections')->middleware('can:couriers.manage-collections')->name('admin.courier-manager.collections.')->group(function () {

--- a/src/Http/Controllers/CourierServiceGroupsController.php
+++ b/src/Http/Controllers/CourierServiceGroupsController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Techquity\Aero\Couriers\Http\Controllers;
+
+use Aero\Admin\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Techquity\Aero\Couriers\Http\Requests\CourierServiceGroupRequest;
+use Techquity\Aero\Couriers\Http\Requests\CourierServiceRequest;
+use Techquity\Aero\Couriers\Models\CourierService;
+use Techquity\Aero\Couriers\Models\CourierServiceGroup;
+use Techquity\Aero\Couriers\ResourceLists\CourierServiceGroupsResourceList;
+use Techquity\Aero\Couriers\ResourceLists\CourierServicesResourceList;
+use Techquity\Aero\Couriers\Traits\UsesCourierDriver;
+
+class CourierServiceGroupsController extends Controller
+{
+    use UsesCourierDriver;
+
+    public function index(CourierServiceGroupsResourceList $list, Request $request, ?CourierServiceGroup $group = null)
+    {
+        return view('couriers::resource-lists.service-groups', [
+            'list' => $list = $list(),
+            'results' => $list->apply($request->all())
+                ->paginate($request->input('per_page', 24) ?? 24),
+            'group' => $group
+        ]);
+    }
+
+    public function update(CourierServiceGroupRequest $request, CourierServiceGroup $group)
+    {
+        $group->update($request->validated());
+
+        return redirect()->route('admin.courier-manager.service-groups.index')->with([
+            'message' => __('Group :group was successfully updated.', [
+                'group' => $group->name
+            ]),
+        ]);
+    }
+
+    public function store(CourierServiceGroupRequest $request)
+    {
+        CourierServiceGroup::create($request->validated());
+
+        return redirect()->route('admin.courier-manager.service-groups.index')->with([
+            'message' => __('A new courier service group was created'),
+        ]);
+    }
+}

--- a/src/Http/Controllers/CourierServicesController.php
+++ b/src/Http/Controllers/CourierServicesController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Techquity\Aero\Couriers\Http\Requests\CourierServiceRequest;
 use Techquity\Aero\Couriers\Models\CourierService;
+use Techquity\Aero\Couriers\Models\CourierServiceGroup;
 use Techquity\Aero\Couriers\ResourceLists\CourierServicesResourceList;
 use Techquity\Aero\Couriers\Traits\UsesCourierDriver;
 
@@ -41,6 +42,9 @@ class CourierServicesController extends Controller
             resolve($driver)->getServices()->each(function ($service) use ($driver) {
                 $service['service_type'] = isset($service['service_type']) ? $service['service_type'] : $service['service_code'];
 
+                $service['courier_service_group_id'] =
+                    isset($service['group']) ? CourierServiceGroup::firstOrCreate(['name' => $service['group']])->id : null;
+
                 $model = CourierService::query()
                     ->where('carrier', $driver::NAME)
                     ->where('service_type', $service['service_type'])
@@ -52,7 +56,7 @@ class CourierServicesController extends Controller
                 } else {
                     $model->update([
                         'description' => $service['description'],
-                        'group' => $service['group'] ?? 'Standard',
+                        'courier_service_group_id' => $model->courier_service_group_id ?? $service['courier_service_group_id'],
                     ]);
                 }
             });

--- a/src/Http/Requests/CourierServiceGroupRequest.php
+++ b/src/Http/Requests/CourierServiceGroupRequest.php
@@ -3,15 +3,14 @@
 namespace Techquity\Aero\Couriers\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
-class CourierServiceRequest extends FormRequest
+class CourierServiceGroupRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
-     *
-     * @return bool
      */
-    public function authorize()
+    public function authorize(): bool
     {
         return $this->user()->can('couriers.manage-services');
     }
@@ -24,8 +23,12 @@ class CourierServiceRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'max:255',
-            'courier_service_group_id' => 'nullable|exists:courier_service_groups,id'
+            'name' => [
+                'required',
+                'max:255',
+                Rule::unique('courier_service_groups', 'name')->ignore($this->group),
+            ],
+            'sort' => 'nullable|numeric',
         ];
     }
 }

--- a/src/Models/CourierServiceGroup.php
+++ b/src/Models/CourierServiceGroup.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Techquity\Aero\Couriers\Models;
+
+use Aero\Common\Models\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CourierServiceGroup extends Model
+{
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'sort',
+    ];
+}

--- a/src/ResourceLists/CourierServiceGroupsResourceList.php
+++ b/src/ResourceLists/CourierServiceGroupsResourceList.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Techquity\Aero\Couriers\ResourceLists;
+
+use Aero\Admin\ResourceLists\AbstractResourceList;
+use Aero\Admin\ResourceLists\ResourceListColumn;
+use Aero\Admin\ResourceLists\ResourceListSortBy;
+use Aero\Admin\Traits\IsExtendable;
+use Illuminate\Routing\Route;
+use Techquity\Aero\Couriers\Filters\CarrierAdminFilter;
+use Techquity\Aero\Couriers\Models\CourierService;
+use Techquity\Aero\Couriers\Models\CourierServiceGroup;
+
+class CourierServiceGroupsResourceList extends AbstractResourceList
+{
+    use IsExtendable;
+
+    protected $headerSlot = 'couriers.services.index.header.buttons';
+
+    protected $selected;
+
+    public function __construct(CourierServiceGroup $group)
+    {
+        $this->resource = $group;
+        $this->selected = optional(app(Route::class)->parameter('group'))->id;
+    }
+
+    protected function columns(): array
+    {
+        return [
+            ResourceListColumn::create('Name', function ($row) {
+                return $row->name;
+            }),
+            ResourceListColumn::create('Sort', function ($row) {
+                return $row->sort;
+            }),
+            ResourceListColumn::create('', function ($row) {
+                if ($row->id === $this->selected) {
+                    return view('couriers::resource-lists.cancel-link', [
+                        'route' => route('admin.courier-manager.service-groups.index', array_merge(request()->all())),
+                    ])->render();
+                } else {
+                    return view('admin::resource-lists.manage-link', [
+                        'route' => route('admin.courier-manager.service-groups.edit', array_merge(request()->all(), ['group' => $row])),
+                    ])->render();
+                }
+            }, 'action'),
+        ];
+    }
+
+    protected function sortBys(): array
+    {
+        return [
+            ResourceListSortBy::create(null, function ($_, $query) {
+                return $query->orderBy('sort');
+            }),
+
+            ResourceListSortBy::create([
+                'name-az' => 'Name A to Z',
+                'name-za' => 'Name Z to A',
+            ], function ($sortBy, $query) {
+                return $sortBy === 'name-az' ? $query->orderBy('name') : $query->orderByDesc('name');
+            }),
+        ];
+    }
+
+    protected function newQuery()
+    {
+        if (array_key_exists('deleted', $this->parameters)) {
+            return $this->resource->newQuery()->withTrashed()->whereNotNull('deleted_at');
+        }
+
+        return $this->resource->newQuery();
+    }
+
+    protected function handleSearch($search)
+    {
+        $this->query->where(function ($query) use ($search) {
+            $query->whereLower('name', 'like', "%{$search}%");
+        });
+    }
+
+    public function backButtonLink()
+    {
+        return route('admin.courier-manager.services.index');
+    }
+
+    public function title(): string
+    {
+        return 'Courier Service Groups';
+    }
+}

--- a/src/ResourceLists/CourierServicesResourceList.php
+++ b/src/ResourceLists/CourierServicesResourceList.php
@@ -38,7 +38,7 @@ class CourierServicesResourceList extends AbstractResourceList
                 return $row->description;
             }),
             ResourceListColumn::create('Group', function ($row) {
-                return $row->group;
+                return $row->courierServiceGroup ? $row->courierServiceGroup->name : '';
             }),
             ResourceListColumn::create('Carrier', function ($row) {
                 return $row->carrier;


### PR DESCRIPTION
This was previously implemented as a basic text field - https://github.com/techquityltd/aero-couriers/pull/4 - however this gives us limited options to maintain groups and also results in lots of redundant data.

Now implemented this properly with courier service groups as a standalone database table which are linked as a foreign key to courier services. This allows us to easily rename groups and implement a sort order as well as add new groups.