### PR TITLE
Adds bulk option to print labels

### DIFF
--- a/src/Actions/PrintLabels.php
+++ b/src/Actions/PrintLabels.php
@@ -15,7 +15,9 @@ class PrintLabels
             ->groupBy(fn ($shipment) => $shipment->courierConnector->id)
             ->each(function ($shipments) use ($admin) {
                 $driver = $this->getCourierDrivers()->get($shipments->first()->courierService->carrier);
-                (new $driver())->printLabels($shipments);
+                $driver = (new $driver())->setShipments($shipments);
+
+                $driver->printLabels($admin);
             });
 
         return true;

--- a/src/Actions/PrintLabels.php
+++ b/src/Actions/PrintLabels.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Techquity\Aero\Couriers\Actions;
+
+use Aero\Admin\Models\Admin;
+use Techquity\Aero\Couriers\Traits\UsesCourierDriver;
+
+class PrintLabels
+{
+    use UsesCourierDriver;
+
+    public function __invoke($shipments, Admin $admin)
+    {
+        $shipments
+            ->groupBy(fn ($shipment) => $shipment->courierConnector->id)
+            ->each(function ($shipments) use ($admin) {
+                $driver = $this->getCourierDrivers()->get($shipments->first()->courierService->carrier);
+                (new $driver())->printLabels($shipments);
+            });
+
+        return true;
+    }
+}

--- a/src/BulkActions/PrintLabelsBulkAction.php
+++ b/src/BulkActions/PrintLabelsBulkAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Techquity\Aero\Couriers\BulkActions;
+
+use Aero\Admin\ResourceLists\FulfillmentsResourceList;
+use Aero\Fulfillment\Models\Fulfillment;
+use Illuminate\Support\Facades\Auth;
+use Techquity\Aero\Couriers\Abstracts\AbstractQueueableBulkAction;
+use Techquity\Aero\Couriers\Actions\PrintLabels;
+use Techquity\Aero\Couriers\Traits\UsesCourierDriver;
+
+class PrintLabelsBulkAction extends AbstractQueueableBulkAction
+{
+    use UsesCourierDriver;
+
+    protected $list;
+    protected $admin;
+
+    public function __construct(FulfillmentsResourceList $list)
+    {
+        $this->list = $list;
+        $this->admin = Auth::user();
+    }
+
+    public function handle(): void
+    {
+        if (! $this->admin) {
+            return;
+        }
+
+        $shipments = $this->list->items()
+            ->filter(fn (Fulfillment $fulfillment) => $fulfillment->courierShipment)
+            ->filter(fn (Fulfillment $fulfillment) => $fulfillment->courierShipment->consignment_number)
+            ->map(fn (Fulfillment $fulfillment) => $fulfillment->courierShipment)
+            ->all();
+
+        if (count($shipments)) {
+            (new PrintLabels())(collect($shipments), $this->admin);
+        }
+    }
+}

--- a/src/CourierDriver.php
+++ b/src/CourierDriver.php
@@ -112,6 +112,11 @@ class CourierDriver extends FulfillmentDriver
         });
     }
 
+    public function printLabels(): void
+    {
+
+    }
+
     /**
      * Get the the tracking url.
      */

--- a/src/CourierDriver.php
+++ b/src/CourierDriver.php
@@ -11,6 +11,7 @@ use Aero\Fulfillment\Responses\FulfillmentResponse;
 use Illuminate\Support\Collection;
 use Techquity\Aero\Couriers\Actions\CommitShipments;
 use Techquity\Aero\Couriers\Models\CourierCollection;
+use Techquity\Aero\Couriers\Models\CourierConnector;
 use Techquity\Aero\Couriers\Models\CourierShipment;
 use Techquity\Aero\Couriers\Models\PendingLabel;
 use Illuminate\Database\Eloquent;
@@ -112,13 +113,16 @@ class CourierDriver extends FulfillmentDriver
         });
     }
 
-    public function printLabels(): void
+    /**
+     * Print the labels for the given shipments
+     */
+    public function printLabels($admin)
     {
 
     }
 
     /**
-     * Get the the tracking url.
+     * Get the tracking url.
      */
     protected function getTrackingUrl(string $trackingCode): string
     {
@@ -227,5 +231,10 @@ class CourierDriver extends FulfillmentDriver
                 }
             });
         }
+    }
+
+    protected function getCourierConnector($name = null): CourierConnector
+    {
+        return CourierConnector::where('name', $name)->first();
     }
 }

--- a/src/CouriersServiceProvider.php
+++ b/src/CouriersServiceProvider.php
@@ -20,6 +20,7 @@ use Techquity\Aero\Couriers\BulkActions\CompletePendingFulfillments;
 use Techquity\Aero\Couriers\BulkActions\DeleteCourierConnectorsBulkAction;
 use Techquity\Aero\Couriers\BulkActions\DeleteCourierServicesBulkAction;
 use Techquity\Aero\Couriers\Models\{CourierConnector, CourierService, CourierShipment, PendingLabel};
+use Techquity\Aero\Couriers\BulkActions\PrintLabelsBulkAction;
 use Techquity\Aero\Couriers\ResourceLists\CourierConnectorsResourceList;
 use Techquity\Aero\Couriers\ResourceLists\CourierServicesResourceList;
 use Techquity\Aero\Couriers\BulkActions\MergeCourierShipmentsBulkAction;
@@ -80,15 +81,13 @@ class CouriersServiceProvider extends ModuleServiceProvider
             return view('couriers::slots.pending-labels');
         });
 
-        BulkAction::create(CompletePendingFulfillments::class, FulfillmentsResourceList::class)
-            ->title('Complete pending fulfillments')
-            ->permissions('fulfillments.view');
-
         $this->configureCourierManagerModule();
 
         $this->configureFulfillmentMethodsSetup();
 
         $this->configureFulfillmentSetup();
+
+        $this->configureFulfillmentBulkActions();
     }
 
     /**
@@ -224,5 +223,16 @@ class CouriersServiceProvider extends ModuleServiceProvider
         $this->extendRequestForSelector(UpdateFulfillmentRequest::class);
 
         AdminOrderFulfillmentUpdate::extend(UpdateFulfillmentShipment::class);
+    }
+
+    protected function configureFulfillmentBulkActions(): void
+    {
+        BulkAction::create(CompletePendingFulfillments::class, FulfillmentsResourceList::class)
+            ->title('Complete pending fulfillments')
+            ->permissions('fulfillments.view');
+
+        BulkAction::create(PrintLabelsBulkAction::class, FulfillmentsResourceList::class)
+            ->title('Print labels')
+            ->permissions('fulfillments.view');
     }
 }

--- a/src/CouriersServiceProvider.php
+++ b/src/CouriersServiceProvider.php
@@ -77,9 +77,7 @@ class CouriersServiceProvider extends ModuleServiceProvider
             }, 'orders');
         });
 
-        AdminSlot::inject('orders.index.header.buttons', function ($_) {
-            return view('couriers::slots.pending-labels');
-        });
+        $this->setupPendingLabelsDownloader();
 
         $this->configureCourierManagerModule();
 
@@ -234,5 +232,16 @@ class CouriersServiceProvider extends ModuleServiceProvider
         BulkAction::create(PrintLabelsBulkAction::class, FulfillmentsResourceList::class)
             ->title('Print labels')
             ->permissions('fulfillments.view');
+    }
+
+    /**
+     * Adds the view for pending labels so pending labels are automatically downloaded in the admin
+     */
+    protected function setupPendingLabelsDownloader(): void
+    {
+        $fn = fn ($_) => view('couriers::slots.pending-labels');
+
+        AdminSlot::inject('orders.index.header.buttons', $fn);
+        AdminSlot::inject('orders.fulfillments.index.header.buttons', $fn);
     }
 }


### PR DESCRIPTION
Labels are currently only accessible by manually editing a fulfillment and clicking Print Label. This adds a bulk action which allows us to download labels automatically.